### PR TITLE
chore: sync EPF wiki updates and zh translation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,26 +1,25 @@
-## Wiki PR Checklist
+## 清单
 
-Thank you for contributing to the Protocol Wiki! Before you open a PR, make sure to read [information for contributors](https://epf.wiki/#/contributing) and take a look at following checklist:
+感谢你为 Protocol Wiki 做贡献！在提交 PR 前，请先阅读[贡献者信息](https://epf.wiki/#/contributing)，并查看以下清单：
 
-- [ ] Describe your changes, substitute this text with the information
-- [ ] If you are touching an existing piece of content, ask the original creator for review 
-- [ ] If you need feedback for your content from wider community, share the PR in our Discord
-- [ ] Review changes to ensure there are no typos, see instructions bellow
+- [ ] 描述你的变更，用实际说明替换这段文字
+- [ ] 如果你修改了已有内容，请邀请[相关维护者](https://github.com/eth-protocol-fellows/protocol-studies/blob/maintainers/README.md#wiki-maintainers)进行审核
+- [ ] 如果你需要更广泛社区对内容提供反馈，请在我们的 Discord 中分享该 PR
+- [ ] 检查变更以确保没有拼写错误，参见下面的说明
 
-<!-- 
-ℹ️ Checking for typos locally
-1. Install [aspell](https://www.gnu.org/software/aspell/) for your platform.
-2. Navigate to the project root and run:
+<!--
+ℹ️ 本地检查拼写错误
+1. 为你的平台安装 [aspell](https://www.gnu.org/software/aspell/)。
+2. 进入项目根目录并运行脚本：
 ```
- for f in **/*.md ; do echo $f ; aspell --lang=en_US --mode=markdown --home-dir=. --personal=wordlist.txt --ignore-case=true --camel-case list  < $f | sort | uniq -c ; done
+./check_typos.sh
 ```
 
-ℹ️ Fixing typos
-1. Fix typos: Open the relevant files and fix any identified typos.
-2. Update wordlist: If a flagged word is actually a project-specific term add it to `wordlist.txt` in the project root.
-   Each word should be listed on a separate line.
- * 🚧 Remember:
-    * When adding new words it must NOT have any spaces or special characters within or around it.
-    * \`wordlist\` is NOT case sensitive.
-    * Use backticks to quote code variables so as to not bloat the \`wordlist\`.
+ℹ️ 修复拼写错误
+* 如果发现拼写错误，请修正。
+* 如果误报的单词不在 `wordlist.txt` 中，请将其加入该文件，并注意：
+    * 添加新词时，词内或词周围不得包含空格或特殊字符。
+    * `wordlist` 不区分大小写。
+    * 使用反引号包裹代码变量，避免让 `wordlist` 膨胀。
+    * 使用 HTML 标签 <name> 包裹专有名称，例如 <name>John Doe</name>。
 -->


### PR DESCRIPTION
## Summary
- Sync weekly EPF wiki updates from upstream `eth-protocol-fellows/protocol-studies` into the Chinese fork.
- Preserve Chinese fork translations while absorbing compatible upstream metadata/template changes.
- Translate updated PR template checklist/instructions into Simplified Chinese.
- Keep the English spell-check workflow deleted to avoid false positives on Chinese content.

## Verification
- `git diff --check`
- `git grep -n -I -E '<<<<<<<|>>>>>>>' -- '*.md' '*.mdx' '*.txt' '*.yml' '*.yaml'`

## Conflict resolution
- Markdown/MDX/TXT/YAML conflicts: preferred existing Chinese content where semantically corresponding.
- Config/workflow conflict: preserved deletion of `.github/workflows/spell-check.yml`.
